### PR TITLE
Add support for configuring template directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ pip-wheel-metadata/
 .nox
 outputs/
 .nox/*
+*.retry
 

--- a/pb_test_configs.yml
+++ b/pb_test_configs.yml
@@ -6,41 +6,44 @@
   connection: local
 
   vars:
-    output_dir: "outputs"
+    output_dir: "tests/outputs"
     test_dir: "tests"
+    template_dir: "{% set env_var = lookup('env', 'TEMPLATE_DIR') %}{% if env_var %}{{ env_var }}{% else %}templates{% endif %}"
 
   tasks:
 
     - name: "MAIN: GATHER ALL TEST DATA FILES"
       find:
-        paths: ./tests
+        paths: "./tests"
         patterns: "data.yml"
         recurse: true
-      register: test_data_files
+      register: "test_data_files"
 
     - name: "MAIN: REMOVE PREVIOUS OUTPUT DIRECTORIES"
       file:
         path: "{{ output_dir }}"
-        state: absent
+        state: "absent"
 
     - name: "MAIN: REMOVE LAST JOB SUMMARY FILE"
       file:
         path: "job-summary.txt"
-        state: absent
+        state: "absent"
 
     - name: "MAIN: CREATE REQUIRED OUTPUT DIRECTORY STRUCTURE 01"
       file:
         path: "{{ output_dir }}/reports"
-        state: directory
+        state: "directory"
 
     - name: "MAIN: CREATE REQUIRED OUTPUT DIRECTORY STRUCTURE 02"
       file:
         path: "/tmp/ntc"
-        state: directory
+        state: "directory"
 
     - name: "MAIN: EXECUTE TESTS"
-      include_tasks: tasks_config_tester.yml
+      include_tasks: "tasks_config_tester.yml"
       loop: "{{ test_data_files['files'] }}"
+      loop_control:
+        loop_var: "test_file"
 
     - name: "MAIN: GENERATE MASTER LOG"
       assemble:
@@ -60,7 +63,7 @@
     - name: "MAIN: ADD SUMMARY TO MASTER LOG"
       lineinfile:
         path: "job-summary.txt"
-        insertafter: EOF
+        insertafter: "EOF"
         line: |
 
           Summary: {{ test_data_files['files'] | length }} data files tested

--- a/tasks_config_tester.yml
+++ b/tasks_config_tester.yml
@@ -1,15 +1,15 @@
 ---
 
-  # item is name of the data yaml file
+  # test_file is name of the data yaml file
   # the initating loop can be found in 
   # the playbook iterating over all data files
   # look for MAIN: EXECUTE ALL TESTS task
   - name: "TASKS: TESTING BEGINNING"
     set_fact:
       # path = tests/vlans/test_01/data.yml
-      feature: "{{ item.path.split('/')[1] }}"
-      test_name: "{{ item.path.split('/')[2] }}"
-      data_file: "{{ item.path }}"
+      feature: "{{ test_file.path.split('/')[1] }}"
+      test_name: "{{ test_file.path.split('/')[2] }}"
+      data_file: "{{ test_file.path }}"
 
   - name: "{{ feature | upper }}: {{ test_name | upper }}-> LOAD DATA"
     include_vars:
@@ -22,38 +22,39 @@
   - name: "{{ feature | upper }}: {{ test_name | upper }}-> CREATE DIRECTORY STRUCTURE"
     file:
       path: "{{ test_path }}"
-      state: directory
+      state: "directory"
 
   - name: "{{ feature | upper }}: {{ test_name | upper }}-> GENERATE {{ feature | upper }} CONFIG"
     template:
-      src: "{{ template }}"
-      dest: ./{{ test_path }}/generated_config.cfg
-    with_first_found:
-      - "{{ test_dir }}/{{ feature }}/{{ test_name }}/{{ feature }}.j2"
-      - "templates/{{ meta['vendor'] }}/{{ meta['os'] }}/{{ platform }}/{{ family }}/{{ model }}/{{ feature }}.j2"
-      - "templates/{{ meta['vendor'] }}/{{ meta['os'] }}/{{ platform }}/{{ family }}/defaults/{{ feature }}.j2"
-      - "templates/{{ meta['vendor'] }}/{{ meta['os'] }}/{{ platform }}/defaults/{{ feature }}.j2"
-      - "templates/{{ meta['vendor'] }}/{{ meta['os'] }}/defaults/{{ feature }}.j2"
-      - "templates/{{ meta['vendor'] }}/defaults/{{ feature }}.j2"
-      - "{{ feature }}.j2"
-    loop_control:
-      loop_var: template
+      src: "{{ lookup('first_found', file_paths) }}"
+      dest: "./{{ test_path }}/generated_config.cfg"
+    vars:
+      file_paths:
+        files: "{{ feature }}.j2"
+        paths:
+          - "{{ test_dir }}/{{ feature }}/{{ test_name }}"
+          - "{{ template_dir }}/{{ meta['vendor'] }}/{{ meta['os'] }}/{{ meta.get('platform') }}/{{ meta.get('family') }}/{{ meta.get('model') }}"
+          - "{{ template_dir }}/{{ meta['vendor'] }}/{{ meta['os'] }}/{{ meta.get('platform') }}/{{ meta.get('family') }}/defaults"
+          - "{{ template_dir }}/{{ meta['vendor'] }}/{{ meta['os'] }}/{{ meta.get('platform') }}/defaults"
+          - "{{ template_dir }}/{{ meta['vendor'] }}/{{ meta['os'] }}/defaults"
+          - "{{ template_dir }}/{{ meta['vendor'] }}/defaults"
+          - "./"
     ignore_errors: true
-    register: template_status
+    register: "template_status"
 
   - name: "{{ feature | upper }}: {{ test_name | upper }}-> COMPARE EXPECTED TO TEST RESULTS"
     ntc_differ:
       pre_change: "{{ test_dir }}/{{ feature }}/{{ test_name }}/expected_config.cfg"
       post_change: "{{ test_path }}/generated_config.cfg"
       dest: "./{{ test_path }}/test_results.cfg"
-    register: diff
-    when: template_status['changed']
+    register: "diff"
+    when: "template_status['changed']"
 
   - name: "{{ feature | upper }}: {{ test_name | upper }}-> TEMPLATE FAILURE TO TEST RESULTS"
     copy:
-      content: "{{ template_status['results'][0]['msg'] }}"
+      content: "{{ template_status['msg'] }}"
       dest: "./{{ test_path }}/test_results.cfg"
-    when: template_status is failed
+    when: "template_status is failed"
 
   - name: "{{ feature | upper }}: {{ test_name | upper }}-> SHOW THE DIFF"
     debug:
@@ -62,12 +63,11 @@
   - name: "{{ feature | upper }}: {{ test_name | upper }}-> ASSERT THAT THERE IS NO DIFF"
     assert:
       that: 
-        - diff.diff_output == ""
+        - "diff.diff_output == ''"
     ignore_errors: true
-    register: assert_result
+    register: "assert_result"
 
   - name: "{{ feature | upper }}: {{ test_name | upper }}-> GENERATE TEST LOG"
     template:
       src: "report.j2"
       dest: "{{ output_dir }}/reports/{{ feature }}_{{ test_name }}.txt"
-


### PR DESCRIPTION
Still need to add documentation for this, but precedence would be:
  * extra-vars: `-e template_dir=$template_directory`
  * env: `export TEMPLATE_DIR=$template_directory`
  * static: `templates/`

Also:
  * made quotes consistent
  * Use loop_var to name the looping variable
  * Updated `with_first_found` to use `lookup` as per Ansible's current best practice